### PR TITLE
Fix theshit aliases 

### DIFF
--- a/src/shells/bash.rs
+++ b/src/shells/bash.rs
@@ -9,14 +9,15 @@ pub fn get_shell_function(name: &str, path: &Path) -> String {
         "
 {name}() {{
     export SH_SHELL=bash;
-    local SH_PREV_CMD=\"$(fc -ln -1)\";
-    export SH_PREV_CMD;
+    export SH_PREV_CMD=\"$(fc -ln -1)\";
+    export SH_SHELL_ALIASES=\"$(alias)\";
     
     local SH_CMD;
     SH_CMD=$(
       command {} fix \"$@\"
     ) && eval \"$SH_CMD\";
-    
+
+    unset SH_SHELL_ALIASES;
     unset SH_PREV_CMD;
     unset SH_SHELL;
 }}
@@ -50,7 +51,10 @@ pub fn get_aliases() -> HashMap<String, String> {
             {
                 value = &value[1..value.len() - 1];
             }
-            aliases.insert(name.to_string(), value.to_string());
+            aliases.insert(
+                name.replacen("alias ", "", 1).to_string(),
+                value.to_string(),
+            );
         }
     }
     aliases

--- a/src/shells/zsh.rs
+++ b/src/shells/zsh.rs
@@ -17,7 +17,8 @@ pub fn get_shell_function(name: &str, path: &Path) -> String {
     SH_CMD=$(
       {} fix $@
     ) && eval \"$SH_CMD\";
-    
+
+    unset SH_SHELL_ALIASES;
     unset SH_PREV_CMD;
     unset SH_SHELL;
 }}


### PR DESCRIPTION
## Description

This pull request introduces improvements to how shell aliases are handled in both the Bash and Zsh integrations. The main changes ensure that aliases are properly exported, unset, and parsed, which enhances compatibility and correctness when running shell commands.

**Shell integration improvements:**

* Bash shell function now exports `SH_SHELL_ALIASES` containing the current aliases, and properly unsets it after execution to avoid polluting the environment.
* Zsh shell function also unsets `SH_SHELL_ALIASES` after execution for consistency and to prevent environment leakage.

**Alias parsing enhancements:**

* The Bash alias parsing logic in `get_aliases()` now removes the `"alias "` prefix from alias names, ensuring correct key names in the returned map.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [x] Manual testing performed
- [x] All existing tests pass

## Checklist

- [x] Code follows project style
- [x] Self-review completed